### PR TITLE
Lab setup: Run WinDbg as Administrator

### DIFF
--- a/exercises/setup/README.md
+++ b/exercises/setup/README.md
@@ -302,7 +302,7 @@ bcdedit /debug on
 
 + Reboot the machine.
 
-+ Run WinDbg (x64). `File` -> `Kernel Debug`. Select the tab `Local`. 
++ Run WinDbg (x64) as Administrator. `File` -> `Kernel Debug`. Select the tab `Local`. 
 A window with Local Kernel Debugger (lkd) will appear.
 
 (If the command prompt is not showing up, from the main menu choose: `Debug` -> `Break`).


### PR DESCRIPTION
Without running it as Administrator, there's an error "system doesn't support kernel debugging."